### PR TITLE
Code revision: use Reuslt, change to lock-free way to send messages, less clone()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
 name = "array-init"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,6 +594,7 @@ name = "carla_autoware_zenoh_bridge"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "atomic_float",
  "carla",
  "carla-ackermann",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,6 +51,9 @@ name = "anyhow"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "approx"
@@ -373,6 +385,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,6 +587,7 @@ dependencies = [
 name = "carla_autoware_zenoh_bridge"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "atomic_float",
  "carla",
  "carla-ackermann",
@@ -570,6 +598,7 @@ dependencies = [
  "r2r",
  "serde",
  "serde_derive",
+ "thiserror",
  "zenoh",
 ]
 
@@ -1176,6 +1205,12 @@ dependencies = [
  "wasi",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
 
 [[package]]
 name = "git-version"
@@ -1788,6 +1823,15 @@ checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
  "hermit-abi 0.2.6",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d864c91689fdc196779b98dba0aceac6118594c2df6ee5d943eb6a8df4d107a"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2441,6 +2485,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2948,9 +2998,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
+checksum = "38a54aca0c15d014013256222ba0ebed095673f89345dd79119d912eb561b7a8"
 dependencies = [
  "autocfg",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 [dependencies]
 zenoh = "0.6.0-beta.1"
 carla = "0.6.0"
-serde = "1.0.147"
-serde_derive = "1.0.147"
+serde = "1.0.152"
+serde_derive = "1.0.152"
 cdr = "0.2.4"
 atomic_float = "0.1.0"
 clap = { version = "4.0.32", features = ["derive"] }
@@ -17,3 +17,5 @@ log = "0.4.17"
 pretty_env_logger = "0.4.0"
 carla-ackermann = "0.1.0"
 r2r = "0.6.4"
+anyhow = { version = "1.0.68", features = ["backtrace"] }
+thiserror = "1.0.38"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ carla-ackermann = "0.1.0"
 r2r = "0.6.4"
 anyhow = { version = "1.0.68", features = ["backtrace"] }
 thiserror = "1.0.38"
+arc-swap = "1.6.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,13 @@
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("ROS error: {0}")]
+    Ros(#[from] r2r::Error),
+
+    #[error("CDR error: {0}")]
+    Cdr(#[from] cdr::Error),
+
+    #[error("{0}")]
+    Other(#[from] Box<dyn std::error::Error + Sync + Send + 'static>),
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,14 @@
+mod error;
 mod vehicle_bridge;
 
+use anyhow::Result;
 use carla::{
     client::{ActorKind, Client},
     prelude::*,
     rpc::ActorId,
 };
 use clap::Parser;
+use error::Error;
 use log::info;
 use r2r::{Clock, ClockType};
 use std::{
@@ -19,13 +22,16 @@ use zenoh::prelude::sync::*;
 /// Command line options
 #[derive(Debug, Clone, Parser)]
 struct Opts {
+    /// Carla simulator address.
     #[clap(long, default_value = "127.0.0.1")]
     pub carla_address: String,
+
+    /// Carla simulator port.
     #[clap(long, default_value = "2000")]
     pub carla_port: u16,
 }
 
-fn main() {
+fn main() -> Result<(), Error> {
     pretty_env_logger::init();
 
     let Opts {
@@ -34,18 +40,18 @@ fn main() {
     } = Opts::parse();
 
     info!("Running Carla Autoware Zenoh bridge...");
-    let z_session = zenoh::open(Config::default()).res().unwrap();
+    let z_session = zenoh::open(Config::default()).res()?;
 
     let client = Client::connect(&carla_address, carla_port, None);
     let world = client.world();
     let mut bridge_list: HashMap<ActorId, VehicleBridge> = HashMap::new();
 
     let mut last_time = Instant::now();
-    let mut clock = Clock::create(ClockType::RosTime).unwrap();
+    let mut clock = Clock::create(ClockType::RosTime)?;
 
     loop {
         let elapsed_time = last_time.elapsed().as_secs_f64();
-        let time = Clock::to_builtin_time(&clock.get_now().unwrap());
+        let time = Clock::to_builtin_time(&clock.get_now()?);
 
         {
             let mut actor_list: HashMap<ActorId, _> = world
@@ -67,8 +73,8 @@ fn main() {
                             .find(|attr| attr.id() == "role_name")
                             .unwrap()
                             .value_string();
-                        info!("Detect vehicles {role_name}");
-                        let v_bridge = VehicleBridge::new(&z_session, role_name, actor);
+                        info!("Detect a vehicle {role_name}");
+                        let v_bridge = VehicleBridge::new(&z_session, role_name, actor)?;
                         bridge_list.insert(id, v_bridge);
                     }
                     ActorKind::Sensor(_) => {
@@ -94,7 +100,7 @@ fn main() {
 
         bridge_list
             .values_mut()
-            .for_each(|bridge| bridge.step(&time, elapsed_time));
+            .try_for_each(|bridge| bridge.step(&time, elapsed_time))?;
         last_time = Instant::now();
         world.wait_for_tick();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,8 +59,8 @@ fn main() -> Result<(), Error> {
                 .iter()
                 .map(|actor| (actor.id(), actor))
                 .collect();
-            let prev_actor_ids = bridge_list.keys().cloned().collect::<HashSet<_>>();
-            let cur_actor_ids = actor_list.keys().cloned().collect::<HashSet<_>>();
+            let prev_actor_ids: HashSet<u32> = bridge_list.keys().cloned().collect();
+            let cur_actor_ids: HashSet<u32> = actor_list.keys().cloned().collect();
             let added_ids = &cur_actor_ids - &prev_actor_ids;
             let deleted_ids = &prev_actor_ids - &cur_actor_ids;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-// mod autoware_type;
 mod vehicle_bridge;
 
 use carla::{
@@ -9,9 +8,11 @@ use carla::{
 use clap::Parser;
 use log::info;
 use r2r::{Clock, ClockType};
-use std::collections::{HashMap, HashSet};
-use std::time::Instant;
-use std::{thread, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    thread,
+    time::{Duration, Instant},
+};
 use vehicle_bridge::VehicleBridge;
 use zenoh::prelude::sync::*;
 

--- a/src/vehicle_bridge.rs
+++ b/src/vehicle_bridge.rs
@@ -1,4 +1,14 @@
+use crate::error::Result;
 use atomic_float::AtomicF32;
+use carla::{
+    client::{ActorBase, Vehicle},
+    rpc::{VehicleControl, VehicleWheelLocation},
+};
+use carla_ackermann::{
+    vehicle_control::{Output, TargetRequest},
+    VehicleController,
+};
+use cdr::{CdrLe, Infinite};
 use log::debug;
 use r2r::{
     autoware_auto_control_msgs::msg::{
@@ -9,20 +19,8 @@ use r2r::{
     std_msgs::msg::Header,
 };
 use std::sync::{atomic::Ordering, Arc, Mutex};
-
-use cdr::{CdrLe, Infinite};
 use zenoh::{
     buffers::reader::HasReader, prelude::sync::*, publication::Publisher, subscriber::Subscriber,
-};
-
-use carla::{
-    client::{ActorBase, Vehicle},
-    rpc::{VehicleControl, VehicleWheelLocation},
-};
-
-use carla_ackermann::{
-    vehicle_control::{Output, TargetRequest},
-    VehicleController,
 };
 
 pub struct VehicleBridge<'a> {
@@ -37,14 +35,13 @@ pub struct VehicleBridge<'a> {
 }
 
 impl<'a> VehicleBridge<'a> {
-    pub fn new(z_session: &'a Session, name: String, actor: Vehicle) -> VehicleBridge<'a> {
+    pub fn new(z_session: &'a Session, name: String, actor: Vehicle) -> Result<VehicleBridge<'a>> {
         let physics_control = actor.physics_control();
         let controller = VehicleController::from_physics_control(&physics_control, None);
 
         let publisher_velocity = z_session
             .declare_publisher(format!("{name}/rt/vehicle/status/velocity_status"))
-            .res()
-            .unwrap();
+            .res()?;
         let speed = Arc::new(AtomicF32::new(0.0));
 
         // TODO: We can use default value here
@@ -61,24 +58,21 @@ impl<'a> VehicleBridge<'a> {
                 let mut cloned_cmd = cloned_cmd.lock().unwrap();
                 *cloned_cmd = cmd;
             })
-            .res()
-            .unwrap();
+            .res()?;
         let _subscriber_gate_mode = z_session
             .declare_subscriber(name.clone() + "/rt/control/gate_mode_cmd")
             .callback_mut(move |_| {
                 // TODO
             })
-            .res()
-            .unwrap();
+            .res()?;
         let subscriber_gear_cmd = z_session
             .declare_subscriber(name.clone() + "/rt/external/selected/gear_cmd")
             .callback_mut(move |_sample| {
                 // TODO: We don't this now, since reverse will be calculated while subscribing control_cmd
             })
-            .res()
-            .unwrap();
+            .res()?;
 
-        VehicleBridge {
+        Ok(VehicleBridge {
             vehicle_name: name,
             actor,
             _subscriber_control_cmd: subscriber_control_cmd,
@@ -87,10 +81,10 @@ impl<'a> VehicleBridge<'a> {
             speed,
             controller,
             current_ackermann_cmd,
-        }
+        })
     }
 
-    fn pub_current_velocity(&mut self, stamp: &Time) {
+    fn pub_current_velocity(&mut self, stamp: &Time) -> Result<()> {
         //let transform = vehicle_actor.transform();
         let velocity = self.actor.velocity();
         //let angular_velocity = vehicle_actor.angular_velocity();
@@ -113,10 +107,12 @@ impl<'a> VehicleBridge<'a> {
             "Carla => Autoware: current velocity: {}",
             velocity_msg.longitudinal_velocity
         );
-        let encoded = cdr::serialize::<_, _, CdrLe>(&velocity_msg, Infinite).unwrap();
-        self.publisher_velocity.put(encoded).res().unwrap();
+        let encoded = cdr::serialize::<_, _, CdrLe>(&velocity_msg, Infinite)?;
+        self.publisher_velocity.put(encoded).res()?;
         self.speed
             .store(velocity_msg.longitudinal_velocity, Ordering::Relaxed);
+
+        Ok(())
     }
 
     fn update_carla_control(&mut self, elapsed_sec: f64) {
@@ -179,9 +175,10 @@ impl<'a> VehicleBridge<'a> {
         });
     }
 
-    pub fn step(&mut self, stamp: &Time, elapsed_sec: f64) {
-        self.pub_current_velocity(stamp);
+    pub fn step(&mut self, stamp: &Time, elapsed_sec: f64) -> Result<()> {
+        self.pub_current_velocity(stamp)?;
         self.update_carla_control(elapsed_sec);
+        Ok(())
     }
 
     pub fn vehicle_name(&self) -> String {

--- a/src/vehicle_bridge.rs
+++ b/src/vehicle_bridge.rs
@@ -48,7 +48,7 @@ impl<'a> VehicleBridge<'a> {
         let current_ackermann_cmd = Arc::new(Mutex::new(AckermannControlCommand::default()));
         let cloned_cmd = current_ackermann_cmd.clone();
         let subscriber_control_cmd = z_session
-            .declare_subscriber(name.clone() + "/rt/external/selected/control_cmd")
+            .declare_subscriber(format!("{name}/rt/external/selected/control_cmd"))
             .callback_mut(move |sample| {
                 let result: Result<AckermannControlCommand, _> =
                     cdr::deserialize_from(sample.payload.reader(), cdr::size::Infinite);
@@ -60,13 +60,13 @@ impl<'a> VehicleBridge<'a> {
             })
             .res()?;
         let _subscriber_gate_mode = z_session
-            .declare_subscriber(name.clone() + "/rt/control/gate_mode_cmd")
+            .declare_subscriber(format!("{name}/rt/control/gate_mode_cmd"))
             .callback_mut(move |_| {
                 // TODO
             })
             .res()?;
         let subscriber_gear_cmd = z_session
-            .declare_subscriber(name.clone() + "/rt/external/selected/gear_cmd")
+            .declare_subscriber(format!("{name}/rt/external/selected/gear_cmd"))
             .callback_mut(move |_sample| {
                 // TODO: We don't this now, since reverse will be calculated while subscribing control_cmd
             })
@@ -181,7 +181,7 @@ impl<'a> VehicleBridge<'a> {
         Ok(())
     }
 
-    pub fn vehicle_name(&self) -> String {
-        self.vehicle_name.clone()
+    pub fn vehicle_name(&self) -> &str {
+        &self.vehicle_name
     }
 }


### PR DESCRIPTION
This PR makes the following changes.

- Use Result to propagate errors
- Switch to lock-free way to keep the most recent AckermannControlCommand
- Remove many clone()